### PR TITLE
Fix order to be o-s-p, add x- prefix on mime type, ignore rdfs:label and rdfs:comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
 Yoda Triples
-=============
-Subject Object Predicate, hmmmmmmmm?
+============
+
+Object Subject Predicate, hmmmmmmmm? This way Yoda speaks: <http://en.wikipedia.org/wiki/Object%E2%80%93subject%E2%80%93verb#Fictitious_languages>.
 
 Usage
-------
+-----
 
 ```ruby
 graph = RDF::Graph.new
 graph << RDF::Statement(RDF::URI('http://example.org/yoda'), RDF.type, RDF::URI('http://example.org/jedi'))
 graph.dump :yodatriples
-# => "<http://example.org/yoda> <http://example.org/jedi> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> .\n"
+# => "<http://example.org/jedi> <http://example.org/yoda> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> .\n"
+```
+
+Yoda is a taciturn creature so extraneous description is stripped from the yodatriples output, notably rdfs:label and rdfs:comment
+
+```ruby
+graph = RDF::Graph.new
+require 'rdf'
+require 'rdf/yoda_triples'
+
+graph = RDF::Graph.new
+graph << RDF::Statement(RDF::URI('http://example.org/yoda'), RDF::RDFS.label, RDF::Literal('Yoda'))
+graph << RDF::Statement(RDF::URI('http://example.org/yoda'), RDF::RDFS.comment, RDF::Literal('Yoda is a small and taciturn creature who speaks with object-subject-verb word order'))
+graph << RDF::Statement(RDF::URI('http://example.org/yoda'), RDF::RDFS.member, RDF::URI('http://en.wikipedia.org/wiki/Galactic_Republic'))
+graph.dump :yodatriples
+# => "\n\n<http://en.wikipedia.org/wiki/Galactic_Republic> <http://example.org/yoda> <http://www.w3.org/2000/01/rdf-schema#member> .\n" 
 ```

--- a/lib/rdf/yoda_triples.rb
+++ b/lib/rdf/yoda_triples.rb
@@ -3,12 +3,17 @@ require 'rdf'
 module RDF::YodaTriples
   class Writer < RDF::NTriples::Writer
     def format_triple(subject, predicate, object, options = {})
-      "%s %s %s ." % [subject, object, predicate].map { |value| format_term(value, options) }
-    end
+      if ( predicate == RDF::RDFS.label or
+           predicate == RDF::RDFS.comment )
+        ""
+      else
+        "%s %s %s ." % [object, subject, predicate].map { |value| format_term(value, options) }
+      end
+  end
   end
 
   class Format < RDF::Format
-    content_type     'application/yoda-triples', :extension => :yodat, :alias => ['text/plain']
+    content_type     'application/x-yoda-triples', :extension => :yodat, :alias => ['text/plain']
     content_encoding 'utf-8'
 
     reader { RDF::YodaTriples::Reader }


### PR DESCRIPTION
Order for Yoda's speech should be O-S-P and there is even an existing description at http://en.wikipedia.org/wiki/Object%E2%80%93subject%E2%80%93verb#Fictitious_languages. Add an 'x-' prefix to the made-up mime type. Also, since Yoda doesn't say more words than are really necessary to convey key meaning, strip any rdfs:label or rdfs:comment triples from the output (has blank line in their place, would need a little more work to remove that).
